### PR TITLE
Add search facets tracking

### DIFF
--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -248,9 +248,9 @@ $elif param and len(docs):
                        $ display = _('yes')
                     $else:
                        $ display = _('no')
-                    <span class="small"><a href="$add_facet_url(header, k)" data-ol-link-track="search_facet_track(header)" title="$_('Filter results for ebook availability')">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
+                    <span class="small"><a href="$add_facet_url(header, k)" data-ol-link-track="$search_facet_track(header)" title="$_('Filter results for ebook availability')">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
                 $else:
-                    <span class="small"><a href="$add_facet_url(header, k)" data-ol-link-track="search_facet_track(header)" title="$_('Filter results for %(facet)s', facet=display)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
+                    <span class="small"><a href="$add_facet_url(header, k)" data-ol-link-track="$search_facet_track(header)" title="$_('Filter results for %(facet)s', facet=display)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
                 </div>
             $if len(counts) > start_facet_count:
                 <div class="facetMoreLess">

--- a/openlibrary/templates/work_search.html
+++ b/openlibrary/templates/work_search.html
@@ -14,6 +14,25 @@ $code:
             return changequery(page=None,**{k:[i for i in param.get(k, []) if i != v]})
         else:
             return changequery(page=None,**{k:None})
+    
+    def search_facet_track(k):
+        facet_map = (
+            ('has_fulltext', 'eBook'),
+            ('author_key', 'Author'),
+            ('subject_facet', 'Subjects'),
+            ('person_facet', 'People'),
+            ('place_facet', 'Places'),
+            ('time_facet', 'Times'),
+            ('first_publish_year', 'First published'),
+            ('publisher_facet', 'Publisher'),
+            ('language', 'Language'),
+            ('public_scan_b', 'Classic eBooks'),
+        )
+
+        return f'SearchFacet|facet_map[k]'
+
+        
+
 
 $ param = {}
 $for p in ['q', 'title', 'author', 'page', 'sort', 'isbn', 'oclc', 'contributor', 'publish_place', 'lccn', 'ia', 'first_sentence', 'publisher', 'author_key', 'debug', 'subject', 'place', 'person', 'time'] + facet_fields:
@@ -229,9 +248,9 @@ $elif param and len(docs):
                        $ display = _('yes')
                     $else:
                        $ display = _('no')
-                    <span class="small"><a href="$add_facet_url(header, k)" title="$_('Filter results for ebook availability')">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
+                    <span class="small"><a href="$add_facet_url(header, k)" data-ol-link-track="search_facet_track(header)" title="$_('Filter results for ebook availability')">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
                 $else:
-                    <span class="small"><a href="$add_facet_url(header, k)" title="$_('Filter results for %(facet)s', facet=display)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
+                    <span class="small"><a href="$add_facet_url(header, k)" data-ol-link-track="search_facet_track(header)" title="$_('Filter results for %(facet)s', facet=display)">$display</a></span>&nbsp;<span class="smaller gray">$commify(count)</span>
                 </div>
             $if len(counts) > start_facet_count:
                 <div class="facetMoreLess">


### PR DESCRIPTION
### #6938 [feature]

### Technical
Implement Google Analytics (data-ol-link-track) to drop down search facet. 
Map out different attributes to legible strings.

### Testing
The analytics are attached to internet archive so I don't know how to test the function yet.
Passed all the automated tests.

### Stakeholders
@cdrini 

<!-- Attribution Disclaimer: By proposing this pull request, I affirm to have made a best-effort and exercised my discretion to make sure relevant sections of this code which substantially leverage code suggestions, code generation, or code snippets from sources (e.g. Stack Overflow, GitHub) have been annotated with basic attribution so reviewers & contributors may have confidence and access to the correct context to evaluate and use this code. -->
